### PR TITLE
Add Parameters to Path

### DIFF
--- a/path.go
+++ b/path.go
@@ -2,11 +2,12 @@ package openapi
 
 // Path -.
 type Path struct {
-	Post   *Operation `json:"post,omitempty" yaml:"post,omitempty"`
-	Get    *Operation `json:"get,omitempty" yaml:"get,omitempty"`
-	Put    *Operation `json:"put,omitempty" yaml:"put,omitempty"`
-	Patch  *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
-	Delete *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Post       *Operation `json:"post,omitempty" yaml:"post,omitempty"`
+	Get        *Operation `json:"get,omitempty" yaml:"get,omitempty"`
+	Put        *Operation `json:"put,omitempty" yaml:"put,omitempty"`
+	Patch      *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Delete     *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Parameters Parameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 }
 
 // Paths -.


### PR DESCRIPTION
👋  Following [Swagger Specification](https://swagger.io/specification/) Parameters are part of the Path Parameter Object. 

This is a minor change to add Parameters to the Path Parameter Object. 

